### PR TITLE
ADO1415135 Dynamic Help Infopopup failure

### DIFF
--- a/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_system_plugin_name
 Bundle-SymbolicName: org.eclipse.help.ui; singleton:=true
-Bundle-Version: 4.6.100.lgc20240221-1200
+Bundle-Version: 4.6.100.lgc20250219-1330
 Bundle-Activator: org.eclipse.help.ui.internal.HelpUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/DefaultHelpUI.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/DefaultHelpUI.java
@@ -315,6 +315,9 @@ public class DefaultHelpUI extends AbstractHelpUI {
 
 		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 		Shell activeShell = getActiveShell();
+		if (activeShell == null && window != null) {
+			activeShell = window.getShell();
+		}
 		if (window != null && isActiveShell(activeShell, window)) {
 			IWorkbenchPage page = window.getActivePage();
 			if (page != null) {


### PR DESCRIPTION
Linux only: "Open in dynamic help" option doesn't work from infopop for "Open window context help" Help Preference. Upon selection, the infopop just reopens again in another location; but dynamic help doesn't open.
![image](https://github.com/user-attachments/assets/6588940d-3a74-4ade-b5c1-732d13166417)
```
-WIndow -> Preferences
Open 'Help' page in 'Preferences' window:
- Click 'Windows' -> 'Preferences...' -> 'Help'
From Help preferences, select 'In an infopop' option for 'Open window context help':
- Under the 'Context help' section ->  select the option 'In an infopop' in the 'Open window context help' dropdown list.
- Click on 'Apply and Close' button
Launch help menu in any editor:
- Press F1 key
- The help menu for the editor opens in an infopop pop-up window
From the infopop, select "Open in dynamic help" option

ER: The infopop disappears, the help opens in the dynamic view on the right side of DSG
AR: The infopop reopens in another location; but dynamic help doesn't open.
```
_DefaultHelpMunu.displayContext_ executes when **Open in dynamic help** link is selected.
```
	at org.eclipse.help.ui.internal.DefaultHelpUI.displayContext(DefaultHelpUI.java:315)
	at org.eclipse.help.ui.internal.ContextHelpDialog.lambda$3(ContextHelpDialog.java:400)
	at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:67)
	at org.eclipse.help.ui.internal.ContextHelpDialog.openDynamicHelp(ContextHelpDialog.java:398)
	at org.eclipse.help.ui.internal.ContextHelpDialog$2.linkActivated(ContextHelpDialog.java:374)
	at org.eclipse.help.ui.internal.HyperlinkHandler.mouseUp(HyperlinkHandler.java:158)
```
_ContextHelpDialog_ is closed prior to _DefaultHelpMunu.displayContext_ execution.
On Linux, temporarily, there is no active shell at this point.

When the active shell is null _displayContext_ executes "_fallback_" code executing _displayContextAsInfopop_.

In this change when _activeShell_ is null we set _activeShell_ to the active workbench window shell.
In this case _HelpView_ is opened in the workbench window as expected.

