### PR TITLE
Do not create the Web Browser preference link when this preference is filtered from UI

### DIFF
--- a/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_system_plugin_name
 Bundle-SymbolicName: org.eclipse.help.ui; singleton:=true
-Bundle-Version: 4.6.100.lgc20250219-1330
+Bundle-Version: 4.6.100.lgc20250220-1430
 Bundle-Activator: org.eclipse.help.ui.internal.HelpUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/preferences/HelpPreferencePage.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/preferences/HelpPreferencePage.java
@@ -42,6 +42,7 @@ import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.activities.WorkbenchActivityHelper;
 import org.eclipse.ui.dialogs.PreferenceLinkArea;
 import org.eclipse.ui.preferences.IWorkbenchPreferenceContainer;
 import org.osgi.service.prefs.BackingStoreException;
@@ -144,7 +145,10 @@ public class HelpPreferencePage extends PreferencePage implements
 
 	private void createLinkArea(Composite parent) {
 		IPreferenceNode node = getPreferenceNode(WBROWSER_PAGE_ID);
-		if (node != null) {
+		if (node != null &&
+				// do not create the link when preference is filtered from the UI
+				!WorkbenchActivityHelper.filterItem(node)) {
+
 			PreferenceLinkArea linkArea = new PreferenceLinkArea(parent,
 					SWT.WRAP, WBROWSER_PAGE_ID,
 					Messages.HelpPreferencePage_message,


### PR DESCRIPTION
Web Browser preference can be filtered from UI by activity. In this case the link from Help preference will be broken.
Adding additional check to fix this bug. The fix can be contributed to eclipse code

![image](https://github.com/user-attachments/assets/9bfabb58-1d87-49eb-9df0-d2d2e5a3c4a6)
