### PR TITLE
Revert "Temporary Fix: Help-DS isn't responding upon closing Help in the help browser and dialog tray (Linux)."

### DIFF
--- a/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_system_plugin_name
 Bundle-SymbolicName: org.eclipse.help.ui; singleton:=true
-Bundle-Version: 4.6.100.lgc20250220-1430
+Bundle-Version: 4.6.100.lgc20250523-1600
 Bundle-Activator: org.eclipse.help.ui.internal.HelpUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/preferences/HelpPreferencePage.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/preferences/HelpPreferencePage.java
@@ -38,7 +38,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.PlatformUI;
@@ -267,16 +266,6 @@ public class HelpPreferencePage extends PreferencePage implements
 		IEclipsePreferences pref = InstanceScope.INSTANCE.getNode(HelpBasePlugin.PLUGIN_ID);
 		if (useExternalCombo != null) {
 			boolean isExternalBrowser = useExternalCombo.getText().equals(Messages.HelpPreferencePage_externalBrowser);
-			// Temporary Fix: Help-DS isn't responding upon closing Help in the help browser
-			// and dialog tray (Linux). Temporary solution - block "in the help browser".
-			// Will fix in the next release.
-			if (!isExternalBrowser) {
-				MessageBox messageBox = new MessageBox(useExternalCombo.getShell(), SWT.ICON_WARNING | SWT.OK);
-				messageBox.setText("Warning"); //$NON-NLS-1$
-				messageBox.setMessage("Internal browser is not supported!"); //$NON-NLS-1$
-				messageBox.open();
-				return false;
-			}
 			pref.putBoolean(IHelpBaseConstants.P_KEY_ALWAYS_EXTERNAL_BROWSER,
 					isExternalBrowser);
 			BrowserManager.getInstance().setAlwaysUseExternal(

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/LocalScopeDialog.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/LocalScopeDialog.java
@@ -68,10 +68,7 @@ public class LocalScopeDialog extends TrayDialog {
 
 	@Override
 	protected void okPressed() {
-		boolean result = localHelpPage.performOk();
-		if (!result)
-			return;
-		super.okPressed();
+		localHelpPage.performOk();
 	}
 
 }


### PR DESCRIPTION
Help Browser works fine, we don`t need temporary fix https://github.com/Halliburton-Landmark/eclipse.platform.ua/pull/1 .