### PR TITLE
ADO 385650: Help-DS isn't responding upon closing Help in a dialog tray (Linux)

### DIFF
--- a/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_system_plugin_name
 Bundle-SymbolicName: org.eclipse.help.ui; singleton:=true
-Bundle-Version: 4.6.100.lgc20250523-1600
+Bundle-Version: 4.6.100.lgc20250625-1600
 Bundle-Activator: org.eclipse.help.ui.internal.HelpUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/browser/embedded/EmbeddedBrowser.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/browser/embedded/EmbeddedBrowser.java
@@ -33,6 +33,7 @@ import org.eclipse.help.internal.util.ProductPreferences;
 import org.eclipse.help.ui.internal.HelpUIPlugin;
 import org.eclipse.help.ui.internal.Messages;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.util.Util;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
@@ -305,7 +306,24 @@ public class EmbeddedBrowser {
 				}
 			}
 		});
-	}
+
+		// ----------
+		// DSG fix to prevent application hang on browser dispose
+		if (Util.isLinux()) {
+			browser.addDisposeListener(e -> {
+				try {
+					while (Display.getDefault().readAndDispatch()) {
+						;
+						;
+						; // force dispose logic to be processed
+					}
+				} catch (Exception ex) {
+					ILog.of(getClass()).error(ex.getMessage(), ex);
+				}
+			});
+		}
+		// ----------
+}
 
 	private void initializeStatusBar(Browser browser) {
 

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/browser/embedded/EmbeddedBrowser.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/browser/embedded/EmbeddedBrowser.java
@@ -313,8 +313,6 @@ public class EmbeddedBrowser {
 			browser.addDisposeListener(e -> {
 				try {
 					while (Display.getDefault().readAndDispatch()) {
-						;
-						;
 						; // force dispose logic to be processed
 					}
 				} catch (Exception ex) {

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/BrowserPart.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/BrowserPart.java
@@ -38,6 +38,7 @@ import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IStatusLineManager;
 import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.jface.action.Separator;
+import org.eclipse.jface.util.Util;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.LocationEvent;
@@ -234,6 +235,24 @@ public class BrowserPart extends AbstractFormPart implements IHelpPart {
 				}
 			}
 		});
+
+		// ----------
+		// DSG fix to prevent application hang on browser dispose
+		if (Util.isLinux()) {
+			browser.addDisposeListener(e -> {
+				try {
+					while (Display.getDefault().readAndDispatch()) {
+						;
+						;
+						; // force dispose logic to be processed
+					}
+				} catch (Exception ex) {
+					ILog.of(getClass()).error(ex.getMessage(), ex);
+				}
+			});
+		}
+		// ----------
+
 		contributeToToolBar(tbm);
 		contributeToMenu(menuManager);
 	}

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/BrowserPart.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/BrowserPart.java
@@ -242,8 +242,6 @@ public class BrowserPart extends AbstractFormPart implements IHelpPart {
 			browser.addDisposeListener(e -> {
 				try {
 					while (Display.getDefault().readAndDispatch()) {
-						;
-						;
 						; // force dispose logic to be processed
 					}
 				} catch (Exception ex) {


### PR DESCRIPTION
Linux only. 
A DS dialog isn't responding upon closing with the context help opened in the dialog tray.

To fix this we can follow to our general fix that we use across out application