### PR TITLE
ADO 1502909: The Select Topic Scope window does not close when the OK button is clicked

### DIFF
--- a/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
+++ b/ua/org.eclipse.help.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %help_system_plugin_name
 Bundle-SymbolicName: org.eclipse.help.ui; singleton:=true
-Bundle-Version: 4.6.100.lgc20250625-1600
+Bundle-Version: 4.6.100.lgc20250716-1700
 Bundle-Activator: org.eclipse.help.ui.internal.HelpUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/LocalScopeDialog.java
+++ b/ua/org.eclipse.help.ui/src/org/eclipse/help/ui/internal/views/LocalScopeDialog.java
@@ -69,6 +69,7 @@ public class LocalScopeDialog extends TrayDialog {
 	@Override
 	protected void okPressed() {
 		localHelpPage.performOk();
+		super.okPressed();
 	}
 
 }


### PR DESCRIPTION
It seems that a line was removed accidentally in 21787760848335438de5d8bc476a98512f5e9a66